### PR TITLE
Added environment variables INSP_CONNECT_HASH and INSP_CONNECT_PASSWORD

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,21 @@ Use the following environment variables to configure your container:
 |`INSP_ADMIN_NICK`        |`MI5`                           |Nick showed by the `/admin` command           |
 |`INSP_ADMIN_EMAIL`       |`jonny.english@example.com`     |E-mail shown by the `/admin` command          |
 |`INSP_ENABLE_DNSBL`      |`yes`                           |Set to `no` to disable DNSBLs                 |
+|`INSP_CONNECT_PASSWORD`  |`` (empty)                      |Enables a server password, empty to disable   |
+|`INSP_CONNECT_HASH`      |`` (empty)                      |If set, what hash used for the password       |
 
 A quick example how to use the environment variables:
 
 ```console
 $ docker run --name inspircd -p 6667:6667 -e "INSP_NET_NAME=MyExampleNet" inspircd/inspircd-docker
 ```
+
+To use connect password `s3cret` stored with `hmac-sha256`:
+```console
+$ docker run --name inspircd -p 6667:6667 -e "INSP_CONNECT_HASH=hmac-sha256" -e "INSP_CONNECT_PASSWORD=mlknZfDb\$C5E0lXKxdoHFxmsJEfSNe8Ct4XG25slv2WiJvUnnWew" inspircd/inspircd-docker
+```
+*Make sure you escape special chars like `$` or `&` if needed. If you are using `docker-compose` you might need to double escape and use double-dollar signs*
+
 
 ## Oper
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Use the following environment variables to configure your container:
 |`INSP_ADMIN_NICK`        |`MI5`                           |Nick showed by the `/admin` command           |
 |`INSP_ADMIN_EMAIL`       |`jonny.english@example.com`     |E-mail shown by the `/admin` command          |
 |`INSP_ENABLE_DNSBL`      |`yes`                           |Set to `no` to disable DNSBLs                 |
-|`INSP_CONNECT_PASSWORD`  |`` (empty)                      |Enables a server password, empty to disable   |
-|`INSP_CONNECT_HASH`      |`` (empty)                      |If set, what hash used for the password       |
+|`INSP_CONNECT_PASSWORD`  |no default                      |Password eiter as plaintext, or hash value    |
+|`INSP_CONNECT_HASH`      |no default                      |Hashing algorithm for `INSP_CONNECT_PASSWORD` |
 
 A quick example how to use the environment variables:
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Use the following environment variables to configure your container:
 |`INSP_ADMIN_NICK`        |`MI5`                           |Nick showed by the `/admin` command           |
 |`INSP_ADMIN_EMAIL`       |`jonny.english@example.com`     |E-mail shown by the `/admin` command          |
 |`INSP_ENABLE_DNSBL`      |`yes`                           |Set to `no` to disable DNSBLs                 |
-|`INSP_CONNECT_PASSWORD`  |no default                      |Password eiter as plaintext, or hash value    |
+|`INSP_CONNECT_PASSWORD`  |no default                      |Password either as plaintext, or hash value   |
 |`INSP_CONNECT_HASH`      |no default                      |Hashing algorithm for `INSP_CONNECT_PASSWORD` |
 
 A quick example how to use the environment variables:
@@ -72,10 +72,20 @@ A quick example how to use the environment variables:
 $ docker run --name inspircd -p 6667:6667 -e "INSP_NET_NAME=MyExampleNet" inspircd/inspircd-docker
 ```
 
+### Password authentication
+
+You can either set a plaintext password or a hashed password. If you leave `INSP_CONNECT_HASH` unset, the password will be used as a plaintext password.
+
+To use connect password `s3cret` stored in plaintext:
+```console
+$ docker run --name inspircd -p 6667:6667 -e "INSP_CONNECT_PASSWORD=s3cret" inspircd/inspircd-docker
+```
+
 To use connect password `s3cret` stored with `hmac-sha256`:
 ```console
 $ docker run --name inspircd -p 6667:6667 -e "INSP_CONNECT_HASH=hmac-sha256" -e "INSP_CONNECT_PASSWORD=mlknZfDb\$C5E0lXKxdoHFxmsJEfSNe8Ct4XG25slv2WiJvUnnWew" inspircd/inspircd-docker
 ```
+
 *Make sure you escape special chars like `$` or `&` if needed. If you are using `docker-compose` you might need to double escape and use double-dollar signs*
 
 

--- a/conf/config.sh
+++ b/conf/config.sh
@@ -27,6 +27,8 @@ cat <<EOF
 
 # Connect block section
 <define name="usednsbl" value="${INSP_ENABLE_DNSBL:-yes}">
+<define name="connecthash" value="${INSP_CONNECT_HASH}">
+<define name="connectpassword" value="${INSP_CONNECT_PASSWORD}">
 EOF
 
 # Include custom configurations if conf.d exists

--- a/conf/inspircd.conf
+++ b/conf/inspircd.conf
@@ -58,6 +58,17 @@
          # allow: What IP addresses/hosts to allow for this block.
          allow="*"
 
+         # hash: what hash this password is hashed with. requires the module
+         # for selected hash (m_md5.so, m_sha256.so or m_ripemd160.so) be
+         # loaded and the password hashing module (m_password_hash.so)
+         # loaded. Options here are: "md5", "sha256" and "ripemd160".
+         # Optional, but recommended. Create hashed passwords with:
+         # /mkpasswd <hash> <password>
+         hash="&connecthash;"
+
+         # password: Password to use for this block/user(s)
+         password="&connectpassword;"
+
          # maxchans: Maximum number of channels a user in this class
          # be in at one time. This overrides every other maxchans setting.
          #maxchans="30"

--- a/tests/connectConfigPassword.sh
+++ b/tests/connectConfigPassword.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+echo "
+         ######################################
+         ###       Connect config test       ##
+         ###           (Password)            ##
+         ######################################
+"
+
+
+# Make sure tests fails if a command exits with non-zero
+set -e
+
+# shellcheck source=tests/.portconfig.sh
+. $(dirname "$0")/.portconfig.sh
+
+TESTFILE=$(mktemp /tmp/connectConfigPassword.XXXXX)
+
+CONNECTPASSWORD=bob
+CONNECTHASH=sha256
+
+mkdir -p "$(dirname "$TESTFILE")"
+
+# Run container in a simple way
+DOCKERCONTAINER=$(docker run -d -p "127.0.0.1:${CLIENT_PORT}:6667" -p "127.0.0.1:${TLS_CLIENT_PORT}:6697" -e "INSP_CONNECT_PASSWORD=$CONNECTPASSWORD" -e "INSP_CONNECT_HASH=$CONNECTHASH" inspircd:testing)
+
+sleep 10
+
+docker exec "${DOCKERCONTAINER}" /inspircd/conf/config.sh >"$TESTFILE"
+
+grep "name=\"connectpassword\" value=\"$CONNECTPASSWORD\"" "$TESTFILE"
+grep "name=\"connecthash\" value=\"$CONNECTHASH\"" "$TESTFILE"
+
+# Clean up
+rm "$TESTFILE"
+docker stop "${DOCKERCONTAINER}" && docker rm "${DOCKERCONTAINER}"


### PR DESCRIPTION
## Checklist

- [x] Implementation
- [x] Tests
- [x] Docs

Fixes #74 

Added environment variables to control `hash` and `password` in the main connect block.

Added test script tests/connectConfigPassword.sh

Added the environmentvariables to README.md.