### PR TITLE
exec inspircd instead of running in a new process

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,4 +54,4 @@ EOF
 fi
 
 
-/inspircd/bin/inspircd --nofork $@
+exec /inspircd/bin/inspircd --nofork $@


### PR DESCRIPTION
this will allow to send signals to the inspircd process more easily as it becomes pid 1; `docker exec inspircd pkill -SIGHUP inspircd` becomes `docker kill -s HUP inspircd`

i don't think this will break anything, including the ability to use `pkill` as in the first method, it just seems cleaner to me

docs/tests don't seem applicable here, so i've excluded that portion of the pull request template