### PR TITLE
Make it so that conf/*.sh can be trivially overridden by the user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,9 @@ RUN apk add --no-cache libgcc libstdc++ gnutls gnutls-utils $RUN_DEPENDENCIES &&
     addgroup -g 10000 -S inspircd && \
     adduser -u 10000 -h /inspircd/ -D -S -G inspircd inspircd
 
-COPY --chown=inspircd:inspircd conf/ /conf/
 COPY --chown=inspircd:inspircd entrypoint.sh /entrypoint.sh
 COPY --from=builder --chown=inspircd:inspircd /inspircd/ /inspircd/
+COPY --chown=inspircd:inspircd conf/ /inspircd/conf/
 
 USER inspircd
 

--- a/conf/config.sh
+++ b/conf/config.sh
@@ -1,17 +1,6 @@
 #!/bin/sh
 # shellcheck disable=SC2039
 
-########################################
-###                                  ###
-### DON'T EDIT THIS FILE AFTER BUILD ###
-###                                  ###
-###    USE ENVIRONMENT VARIABLES     ###
-###              INSTEAD             ###
-###                                  ###
-########################################
-
-
-
 # Default variables
 cat <<EOF
 # Network section

--- a/conf/inspircd.conf
+++ b/conf/inspircd.conf
@@ -1,6 +1,6 @@
 <config format="xml">
 
-<include executable="./conf/config.sh" noexec="no">
+<include executable="inspircd/conf/config.sh" noexec="no">
 
 #-#-#-#-#-#-#-#-#-#-#-#-  SERVER DESCRIPTION  -#-#-#-#-#-#-#-#-#-#-#-#-
 #                                                                     #
@@ -542,11 +542,11 @@
 
 <exception host="*@127.0.0.1" reason="localhost">
 
-<include executable="conf/opers.sh">
-<include executable="conf/links.sh LINK1">
-<include executable="conf/links.sh LINK2">
-<include executable="conf/links.sh LINK3">
-<include executable="conf/services.sh">
+<include executable="inspircd/conf/opers.sh">
+<include executable="inspircd/conf/links.sh LINK1">
+<include executable="inspircd/conf/links.sh LINK2">
+<include executable="inspircd/conf/links.sh LINK3">
+<include executable="inspircd/conf/services.sh">
 
 <include file="modules.conf">
 

--- a/conf/links.sh
+++ b/conf/links.sh
@@ -1,15 +1,5 @@
 #!/bin/sh
 
-########################################
-###                                  ###
-### DON'T EDIT THIS FILE AFTER BUILD ###
-###                                  ###
-###    USE ENVIRONMENT VARIABLES     ###
-###              INSTEAD             ###
-###                                  ###
-########################################
-
-
 # generateLinkBlock <NAME> <IPADDR> <PORT> <SENDPASS> <RECVPASS> <ALLOWMASK> <MORE>
 generateLinkBlock() {
 if [ "$6" = "" ]; then

--- a/conf/opers.sh
+++ b/conf/opers.sh
@@ -1,14 +1,4 @@
 #!/bin/sh
-########################################
-###                                  ###
-### DON'T EDIT THIS FILE AFTER BUILD ###
-###                                  ###
-###    USE ENVIRONMENT VARIABLES     ###
-###              INSTEAD             ###
-###                                  ###
-########################################
-
-
 
 # Prevent breaking changes
 if [ "$INSP_OPER_PASSWORD_HASH" = "" ] && [ "$INSP_OPER_PASSWORD" != "" ]; then

--- a/conf/services.sh
+++ b/conf/services.sh
@@ -1,15 +1,5 @@
 #!/bin/sh
 
-########################################
-###                                  ###
-### DON'T EDIT THIS FILE AFTER BUILD ###
-###                                  ###
-###    USE ENVIRONMENT VARIABLES     ###
-###              INSTEAD             ###
-###                                  ###
-########################################
-
-
 # When not specified, try to be smart and predict a allowmask
 if [ "$INSP_SERVICES_ALLOWMASK" = "" ]; then
     INSP_SERVICES_ALLOWMASK=$(ip  route show dev eth0 | grep -v default | cut -d" " -f1 | head -1)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,22 +3,6 @@
 
 INSPIRCD_ROOT="/inspircd"
 
-# TODO fix/make configuration better
-# Make sure that the volume contains a default config but don't override an existing one
-if [ ! -e $INSPIRCD_ROOT/conf/inspircd.conf ] && [ -w $INSPIRCD_ROOT/conf/ ]; then
-    cp -r /conf/* $INSPIRCD_ROOT/conf/
-elif [ ! -w $INSPIRCD_ROOT/conf/ ]; then
-    echo "
-        ##################################
-        ###                            ###
-        ###   Can't write to volume!   ###
-        ###    Please change owner     ###
-        ###        to uid 10000        ###
-        ###                            ###
-        ##################################
-    "
-fi
-
 # Link certificates from secrets
 # See https://docs.docker.com/engine/swarm/secrets/
 if [ -e /run/secrets/inspircd.key ] && [ -e /run/secrets/inspircd.crt ]; then


### PR DESCRIPTION
Closes #90

Prior to this commit, editing the conf/*.conf files resulted in
changed configuration parameters, but editing the conf/*.sh files did
not.  Furthermore, there was a comment in the conf/*.sh files that
could be misconstrued.

With this commit the conf/*.sh and conf/*.conf files behave the same.
conf/*.sh files can be edited and then docker -v can be used to bind
mount the conf directory and the changes will take effect.

<!--

Thanks for the contribution!

We provide a little checklist for Pull Requests to make sure everything is fine.

If you are working on a pull request please add WIP to its title. We will still
  look at it and discuss if needed.
-->

## Checklist

- [ ] Implementation
- [ ] Tests
- [ ] Docs

<!--

Some details for the checklist:

Implementation means the complete implementation of your feature.

Tests means adding a shell script in `tests/` to check that your implementation
  works correctly. This makes sure no other pull request breaks a feature. We
  would really welcome it, because simplifies our life.

Docs means additions to the README.md in case you add something which needs
  user interaction or knowledge.

Feel free to place more detail below or on top of your pull request :)

We try to create a great user experience for this image. Every contribution is
  welcome and we help you as good as we can.
-->
