### PR TITLE
Fix broken CI testing, including from `conf.d`

### DIFF
--- a/.dockerfilelintrc
+++ b/.dockerfilelintrc
@@ -1,0 +1,2 @@
+rules:
+    from_first: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   # Initial build with default parameters
   - docker build --build-arg VERSION="${INSP_VERSION}" -t inspircd:testing .
   # Run all tests from test directory
-  - for file in tests/*.sh; do sh $file || exit $?;done
+  - ./run_tests.sh
 
 after_success:
   # Push successful builds of the master branch to Docker Hub

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   # Initial build with default parameters
   - docker build --build-arg VERSION="${INSP_VERSION}" -t inspircd:testing .
   # Run all tests from test directory
-  - for file in tests/*.sh; do $file; done
+  - for file in tests/*.sh; do sh $file || exit $?;done
 
 after_success:
   # Push successful builds of the master branch to Docker Hub

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,3 +50,11 @@ EXPOSE 6667 6697 7000 7001
 
 WORKDIR /
 ENTRYPOINT ["/entrypoint.sh"]
+
+HEALTHCHECK \
+        --interval=1s \
+        --timeout=3s \
+        --start-period=60s \
+        --retries=3 \
+    CMD \
+        /usr/bin/nc -z localhost 6667

--- a/conf/config.sh
+++ b/conf/config.sh
@@ -32,8 +32,8 @@ cat <<EOF
 EOF
 
 # Include custom configurations if conf.d exists
-if [ -d conf.d ]; then
-    find conf.d/*.conf | while read -r file; do echo "<include file=\"$file\">"; done
+if [ -d "${INSPIRCD_ROOT}"/conf.d ]; then
+    find "${INSPIRCD_ROOT}"/conf.d/*.conf | while read -r file; do echo "<include file=\"$file\">"; done
 fi
 
 # Include custom configurations from docker secrets. (For example for further oper configs)

--- a/conf/config.sh
+++ b/conf/config.sh
@@ -33,12 +33,12 @@ EOF
 
 # Include custom configurations if conf.d exists
 if [ -d "${INSPIRCD_ROOT}"/conf.d ]; then
-    find "${INSPIRCD_ROOT}"/conf.d/*.conf | while read -r file; do echo "<include file=\"$file\">"; done
+    find "${INSPIRCD_ROOT}"/conf.d -name '*.conf' | while read -r file; do echo "<include file=\"$file\">"; done
 fi
 
 # Include custom configurations from docker secrets. (For example for further oper configs)
 if [ -d /run/secrets ]; then
-    find /run/secrets/*.conf | while read -r file; do echo "<include file=\"$file\">"; done
+    find /run/secrets -name '*.conf' | while read -r file; do echo "<include file=\"$file\">"; done
 fi
 
 # Space for further configs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,4 +53,5 @@ EOF
     rm /tmp/cert.template
 fi
 
-exec $INSPIRCD_ROOT/bin/inspircd --nofork $@
+cd $INSPIRCD_ROOT
+exec env INSPIRCD_ROOT=$INSPIRCD_ROOT $INSPIRCD_ROOT/bin/inspircd --nofork $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,8 +49,12 @@ time_stamping_key
 EOF
     /usr/bin/certtool --generate-privkey --bits 4096 --sec-param normal --outfile $INSPIRCD_ROOT/conf/key.pem
     /usr/bin/certtool --generate-self-signed --load-privkey $INSPIRCD_ROOT/conf/key.pem --outfile $INSPIRCD_ROOT/conf/cert.pem --template /tmp/cert.template
-    /usr/bin/certtool --generate-dh-params --sec-param normal --outfile $INSPIRCD_ROOT/conf/dhparams.pem
     rm /tmp/cert.template
+fi
+
+# Make sure dhparams are present
+if [ ! -e $INSPIRCD_ROOT/conf/dhparams.pem ]; then
+    /usr/bin/certtool --generate-dh-params --sec-param normal --outfile $INSPIRCD_ROOT/conf/dhparams.pem
 fi
 
 cd $INSPIRCD_ROOT

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+export INSP_VERSION
+
+clean_up() {
+    local ret_val="$?"
+
+    # Clean up any remaining containers (e.g., due to fast-failing test)
+    local inspircd_containers="$(docker ps -q -a -f "ancestor=inspircd:testing")"
+    if [[ -n "${inspircd_containers}" ]]; then
+        docker rm -fv ${inspircd_containers}
+    fi
+
+    # Exit with ultimate exit code
+    exit "${ret_val}"
+}
+trap clean_up EXIT
+
+# Make sure test-tracking file exists
+touch ok_tests.txt
+pad=$(printf '.%.0s' {1..100})
+
+for test_file in tests/*.sh; do
+    printf "%.35s " "${test_file} ${pad}"
+
+    # Check if test already passed.
+    grep -w -q "$(sha1sum "${test_file}")" ok_tests.txt \
+        && { printf "0 ( OK )\n"; continue; } \
+        || true
+
+    # Run test, capturing all output to log variable
+    test_log=$(sh "${test_file}" 2>&1)
+    [[ $? -eq 0 ]] \
+        && {
+            echo "0 ( OK )"
+            sha1sum "${test_file}" >> ok_tests.txt
+        } \
+        || {
+            ret=$?
+            echo "${ret} (FAIL)"
+            # Print full output of test script
+            echo "${test_log}"
+            exit ${ret}
+        }
+done
+# Remove test-tracking cache on successful tests.
+rm ok_tests.txt

--- a/tests/customBuild.sh
+++ b/tests/customBuild.sh
@@ -18,7 +18,7 @@ mkdir -p "$TESTDIR"
 
 cp -r . "$TESTDIR"
 
-wget -O "$TESTDIR/modules/m_timedstaticquit.cpp"  "https://raw.githubusercontent.com/inspircd/inspircd-extras/master/3.0/m_timedstaticquit.cpp"
+wget -O "$TESTDIR/modules/m_timedstaticquit.cpp"  "https://raw.githubusercontent.com/inspircd/inspircd-contrib/master/3.0/m_timedstaticquit.cpp"
 
 [ ! -e "$TESTDIR/modules/m_timedstaticquit.cpp" ] && sleep 10
 

--- a/tests/extras.sh
+++ b/tests/extras.sh
@@ -15,7 +15,7 @@ set -e
 TESTMODULE="m_svsoper"
 
 # Create directory for testing
-mkdir /tmp/test-extras/
+mkdir -p /tmp/test-extras/
 
 docker build --build-arg EXTRASMODULES="$TESTMODULE" .
 

--- a/tests/linking.sh
+++ b/tests/linking.sh
@@ -16,12 +16,12 @@ set -e
 DOCKERNETWORK=$(docker network create linkingTestNet)
 
 # Run first instance of InspIRCd to connect to.
-DOCKERCONTAINER1=$(docker run -d --name test1 --network linkingTestNet -e INSP_SERVER_NAME="test1.example.com" -e INSP_LINK1_NAME="test2.example.com" -e INSP_LINK1_PASSWORD="test" -e INSP_LINK1_IPADDR="test2" inspircd:testing)
+DOCKERCONTAINER1=$(docker run -d --name test1 --network linkingTestNet -e INSP_SERVER_NAME="test1.example.com" -e INSP_LINK1_NAME="test2.example.com" -e INSP_LINK1_PASSWORD="test" -e INSP_LINK1_IPADDR="test2" inspircd:testing --debug)
 
 sleep 5
 
 # Run seconds InspIRCd instance
-DOCKERCONTAINER2=$(docker run -d --name test2 --network linkingTestNet -e INSP_SERVER_NAME="test2.example.com" -e INSP_LINK1_NAME="test1.example.com" -e INSP_LINK1_PASSWORD="test" -e INSP_LINK1_IPADDR="test1" inspircd:testing)
+DOCKERCONTAINER2=$(docker run -d --name test2 --network linkingTestNet -e INSP_SERVER_NAME="test2.example.com" -e INSP_LINK1_NAME="test1.example.com" -e INSP_LINK1_PASSWORD="test" -e INSP_LINK1_IPADDR="test1" inspircd:testing --debug)
 
 sleep 10
 

--- a/tests/mountConfig.sh
+++ b/tests/mountConfig.sh
@@ -14,7 +14,7 @@ set -e
 . "$(dirname "$0")/.portconfig.sh"
 
 # Create config directory for testing
-mkdir /tmp/test-mountConfig/ && sudo chown 10000 /tmp/test-mountConfig/
+mkdir -p /tmp/test-mountConfig/ && sudo chown 10000 /tmp/test-mountConfig/
 
 # Create docker container with our test parameters
 DOCKERCONTAINER=$(docker run -d -v /tmp/test-mountConfig/:/inspircd/conf -p "127.0.0.1:${CLIENT_PORT}:6667" -p "127.0.0.1:${TLS_CLIENT_PORT}:6697" inspircd:testing)

--- a/tests/secrets.sh
+++ b/tests/secrets.sh
@@ -52,7 +52,7 @@ SECRETKEY=$(docker secret create test-secrets-key  /tmp/test-secrets-key.pem)
 DOCKERSERVICE=$(docker service create -q -d -p "${CLIENT_PORT}:6667" -p "${TLS_CLIENT_PORT}:6697" --secret source=test-secrets-key,target=inspircd.key --secret source=test-secrets-cert,target=inspircd.crt inspircd:testing)
 sleep 35
 # Make sure TLS is working
-TLSCHECK=$(echo quit | timeout 10 openssl s_client -ign_eof -connect "localhost:${TLS_CLIENT_PORT}" 2>/dev/null | grep -c "OU=Secret Server Admins")
+TLSCHECK=$(echo quit | timeout 10 openssl s_client -ign_eof -connect "localhost:${TLS_CLIENT_PORT}" 2>/dev/null | grep -c "OU\s*=\s*Secret Server Admins")
 [ "$TLSCHECK" -gt 0 ] || exit 1
 
 sleep 5


### PR DESCRIPTION
This PR started when I noticed that files in a `conf.d` directory mounted according to the docs were not being used. In the processes of tracking down the solution, I also noticed that CI tests were not actually doing anything, and in fact, most of them were in a failing state. Both issues are resolved by this PR.

<sup>*</sup> ```tests: fix failing `customConfig` test``` incidentally addresses the issue in #90

## Checklist

- [x] Implementation <sup>1</sup>
- [x] Tests <sup>2</sup>
- [x] Docs <sup>3</sup>

-----

<sup>1</sup> `tests: fix...` commits are required changes for tests to be able to successfully pass. `tests: refactor...` can be dropped or split off into a new PR if desired, as they are not essential to fixing the main issue of failing tests.

<sup>2</sup> Technically, the `release` test fails because `v3.2.0` has been released. However, this PR has been successfully tested with both versions.

<sup>3</sup> No changes to the docs needed.