### PR TITLE
Fix extra modules compile with run dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN git checkout $(git describe --abbrev=0 --tags $VERSION)
 RUN { [ $(ls /src/modules/ | wc -l) -gt 0 ] && cp -r /src/modules/* /inspircd-src/src/modules/ || echo "No modules overwritten/added by repository"; }
 RUN echo $EXTRASMODULES | xargs --no-run-if-empty ./modulemanager install
 
-RUN ./configure $CONFIGUREARGS --uid 10000 --gid 10000
 RUN ./configure --prefix /inspircd --uid 10000 --gid 10000
+RUN echo $CONFIGUREARGS | xargs --no-run-if-empty ./configure
 RUN make -j`getconf _NPROCESSORS_ONLN` install
 
 ## Wipe out vanilla config; entrypoint.sh will handle repopulating it at runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ARG VERSION=insp3
 ARG CONFIGUREARGS=
 ARG EXTRASMODULES=
 ARG BUILD_DEPENDENCIES=
-ARG RUN_DEPENDENCIES=
 
 # Stage 0: Build from source
 COPY modules/ /src/modules/
@@ -28,7 +27,8 @@ RUN git checkout $(git describe --abbrev=0 --tags $VERSION)
 RUN { [ $(ls /src/modules/ | wc -l) -gt 0 ] && cp -r /src/modules/* /inspircd-src/src/modules/ || echo "No modules overwritten/added by repository"; }
 RUN echo $EXTRASMODULES | xargs --no-run-if-empty ./modulemanager install
 
-RUN ./configure $CONFIGUREARGS --prefix /inspircd --uid 10000 --gid 10000
+RUN ./configure $CONFIGUREARGS
+RUN ./configure --prefix /inspircd --uid 10000 --gid 10000
 RUN make -j`getconf _NPROCESSORS_ONLN` install
 
 ## Wipe out vanilla config; entrypoint.sh will handle repopulating it at runtime
@@ -36,6 +36,9 @@ RUN rm -rf /inspircd/conf/*
 
 # Stage 1: Create optimized runtime container
 FROM alpine:3.9
+
+ARG RUN_DEPENDENCIES=
+
 RUN apk add --no-cache libgcc libstdc++ gnutls gnutls-utils $RUN_DEPENDENCIES && \
     addgroup -g 10000 -S inspircd && \
     adduser -u 10000 -h /inspircd/ -D -S -G inspircd inspircd

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN git checkout $(git describe --abbrev=0 --tags $VERSION)
 RUN { [ $(ls /src/modules/ | wc -l) -gt 0 ] && cp -r /src/modules/* /inspircd-src/src/modules/ || echo "No modules overwritten/added by repository"; }
 RUN echo $EXTRASMODULES | xargs --no-run-if-empty ./modulemanager install
 
-RUN ./configure $CONFIGUREARGS
+RUN ./configure $CONFIGUREARGS --uid 10000 --gid 10000
 RUN ./configure --prefix /inspircd --uid 10000 --gid 10000
 RUN make -j`getconf _NPROCESSORS_ONLN` install
 


### PR DESCRIPTION
<!--

Thanks for the contribution!

We provide a little checklist for Pull Requests to make sure everything is fine.

If you are working on a pull request please add WIP to its title. We will still
  look at it and discuss if needed.
-->

## Checklist

- [x] Implementation
- [ ] Tests
- [ ] Docs

<!--

Some details for the checklist:

Implementation means the complete implementation of your feature.

Tests means adding a shell script in `tests/` to check that your implementation
  works correctly. This makes sure no other pull request breaks a feature. We
  would really welcome it, because simplifies our life.

Docs means additions to the README.md in case you add something which needs
  user interaction or knowledge.

Feel free to place more detail below or on top of your pull request :)

We try to create a great user experience for this image. Every contribution is
  welcome and we help you as good as we can.
-->

Fix problem with mysql module.

Issue: https://github.com/inspircd/inspircd-docker/issues/96

We need fix 2 lines:

1) Separate ./configure in individual step

2) Env RUN_DEPENDENCIES must be declared in Stage 1.

This is the result configuration to add mysql module.

```
Stage 0
ARG CONFIGUREARGS="--enable-extras=m_mysql.cpp"
ARG EXTRASMODULES=
ARG BUILD_DEPENDENCIES="mariadb-connector-c-dev"
```

```
Stage 1
ARG RUN_DEPENDENCIES="mariadb-connector-c"
```